### PR TITLE
Add "Simplex" noise, fix noise range (+ add legacy mode), ridged getMaxValue, update test case

### DIFF
--- a/src/main/java/org/spongepowered/noise/LatticeOrientation.java
+++ b/src/main/java/org/spongepowered/noise/LatticeOrientation.java
@@ -1,0 +1,56 @@
+/*
+ * This file is part of Noise, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Flow Powered <https://github.com/flow>
+ * Copyright (c) SpongePowered <https://github.com/SpongePowered>
+ * Copyright (c) contributors
+ *
+ * Original libnoise C++ library by Jason Bevins <http://libnoise.sourceforge.net>
+ * jlibnoise Java port by Garrett Fleenor <https://github.com/RoyAwesome/jlibnoise>
+ * Noise is re-licensed with permission from jlibnoise author.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.noise;
+
+public enum LatticeOrientation {
+    /**
+     * Generates the simplex-style coherent noise with the classic lattice orientation. Might be better for texturing 3D models, but less good for generating terrain
+     * which has a vertical direction that works differently than the two horizontal directions. There may be subtle diagonal artifacts, similar to classic Simplex.
+     */
+    CLASSIC,
+    /**
+     * Generates simplex-style noise with Y pointing up the main diagonal on the noise lattice. If used properly, this can produce better results than CLASSIC,
+     * when generating 3D worlds with vertical direction that works differently than the two horizontal directions. See the following recommended usage patterns:
+     * - If Y is vertical and X/Z are horizontal, call noise(x, Y, z)
+     * - If Z is vertical and X/Y are horizontal, call noise(x, Z, y) or use mode XYBeforeZ
+     * - If T is time and X/Y or X/Z are horizontal, call noise(x, T, y) or noise(x, T, z), or use mode XYBeforeZ
+     * - If only two coordinates are needed for a 2D noise plane, call noise(x, 0, y) or noise(x, 0, z), or use mode XYBeforeZ
+     */
+    XZBeforeY,
+    /**
+     * Generates simplex-style noise with Z pointing up the main diagonal on the noise lattice. If used properly, this can produce better results than CLASSIC,
+     * when generating 3D worlds with vertical direction that works differently than the two horizontal directions. See the following recommended usage patterns:
+     * - If Y is vertical and X/Z are horizontal, call noise(x, z, Y) or use mode XZBeforeY
+     * - If Z is vertical and X/Y are horizontal, call noise(x, y, Z)
+     * - If T is time and X/Y or X/Z are horizontal, call noise(x, y, T) or noise(x, z, T), or use mode XYBeforeZ
+     * - If only two coordinates are needed for a 2D noise plane, call noise(x, y, 0) or noise(x, z, 0), or use mode XZBeforeY
+     */
+    XYBeforeZ
+}

--- a/src/main/java/org/spongepowered/noise/LatticeOrientation.java
+++ b/src/main/java/org/spongepowered/noise/LatticeOrientation.java
@@ -39,18 +39,18 @@ public enum LatticeOrientation {
      * Generates simplex-style noise with Y pointing up the main diagonal on the noise lattice. If used properly, this can produce better results than CLASSIC,
      * when generating 3D worlds with vertical direction that works differently than the two horizontal directions. See the following recommended usage patterns:
      * - If Y is vertical and X/Z are horizontal, call noise(x, Y, z)
-     * - If Z is vertical and X/Y are horizontal, call noise(x, Z, y) or use mode XYBeforeZ
-     * - If T is time and X/Y or X/Z are horizontal, call noise(x, T, y) or noise(x, T, z), or use mode XYBeforeZ
-     * - If only two coordinates are needed for a 2D noise plane, call noise(x, 0, y) or noise(x, 0, z), or use mode XYBeforeZ
+     * - If Z is vertical and X/Y are horizontal, call noise(x, Z, y) or use mode XY_BEFORE_Z
+     * - If T is time and X/Y or X/Z are horizontal, call noise(x, T, y) or noise(x, T, z), or use mode XY_BEFORE_Z
+     * - If only two coordinates are needed for a 2D noise plane, call noise(x, 0, y) or noise(x, 0, z), or use mode XY_BEFORE_Z
      */
-    XZBeforeY,
+    XZ_BEFORE_Y,
     /**
      * Generates simplex-style noise with Z pointing up the main diagonal on the noise lattice. If used properly, this can produce better results than CLASSIC,
      * when generating 3D worlds with vertical direction that works differently than the two horizontal directions. See the following recommended usage patterns:
-     * - If Y is vertical and X/Z are horizontal, call noise(x, z, Y) or use mode XZBeforeY
+     * - If Y is vertical and X/Z are horizontal, call noise(x, z, Y) or use mode XZ_BEFORE_Y
      * - If Z is vertical and X/Y are horizontal, call noise(x, y, Z)
-     * - If T is time and X/Y or X/Z are horizontal, call noise(x, y, T) or noise(x, z, T), or use mode XYBeforeZ
-     * - If only two coordinates are needed for a 2D noise plane, call noise(x, y, 0) or noise(x, z, 0), or use mode XZBeforeY
+     * - If T is time and X/Y or X/Z are horizontal, call noise(x, y, T) or noise(x, z, T), or use mode XY_BEFORE_Z
+     * - If only two coordinates are needed for a 2D noise plane, call noise(x, y, 0) or noise(x, z, 0), or use mode XZ_BEFORE_Y
      */
-    XYBeforeZ
+    XY_BEFORE_Z
 }

--- a/src/main/java/org/spongepowered/noise/Noise.java
+++ b/src/main/java/org/spongepowered/noise/Noise.java
@@ -66,13 +66,13 @@ public final class Noise {
         if (orientation == LatticeOrientation.CLASSIC) {
             double r = (2.0 / 3.0) * (x + y + z);
             xr = r - x; yr = r - y; zr = r - z;
-        } else if (orientation == LatticeOrientation.XYBeforeZ) {
+        } else if (orientation == LatticeOrientation.XY_BEFORE_Z) {
             double xy = x + y;
             double s2 = xy * -0.211324865405187;
             double zz = z * 0.577350269189626;
             xr = x + s2 - zz; yr = y + s2 - zz;
             zr = xy * 0.577350269189626 + zz;
-        } else { // XZBeforeY
+        } else { // XZ_BEFORE_Y
             double xz = x + z;
             double s2 = xz * -0.211324865405187;
             double yy = y * 0.577350269189626;

--- a/src/main/java/org/spongepowered/noise/Noise.java
+++ b/src/main/java/org/spongepowered/noise/Noise.java
@@ -49,7 +49,7 @@ public final class Noise {
      * @param quality The quality of the coherent-noise.
      * @return The generated gradient-coherent-noise value.
      * <p/>
-     * The return value ranges from 0 to 1.
+     * The return value ranges approximately from 0.3125 to 0.6875
      * <p/>
      * For an explanation of the difference between <i>gradient</i> noise and <i>value</i> noise, see the comments for the GradientNoise3D() function.
      */
@@ -126,7 +126,7 @@ public final class Noise {
      * A <i>gradient</i>-noise function generates better-quality noise than a <i>value</i>-noise function. Most noise modules use gradient noise for this reason, although it takes much longer to
      * calculate.
      * <p/>
-     * The return value ranges from 0 to 1.
+     * The return value ranges from 0 to 1
      * <p/>
      * This function generates a gradient-noise value by performing the following steps: - It first calculates a random normalized vector based on the nearby integer value passed to this function. -
      * It then calculates a new value by adding this vector to the nearby integer value passed to this function. - It then calculates the dot product of the above-generated value and the
@@ -169,7 +169,7 @@ public final class Noise {
      * @param seed The random number seed.
      * @return The generated gradient-coherent-noise value.
      * <p/>
-     * The return value ranges from 0 to 1.
+     * The return value ranges from 0.3125 to 0.6875
      * <p/>
      */
     public static double simplexStyleCoherentNoise3D(double x, double y, double z, int seed) {
@@ -179,7 +179,9 @@ public final class Noise {
         double xr = r - x, yr = r - y, zr = r - z;
 
         // Get base and offsets inside cube of first lattice.
-        int xrb = Utils.floor(xr), yrb = Utils.floor(yr), zrb = Utils.floor(zr);
+        int xrb = ((xr > 0.0) ? (int) xr : (int) xr - 1);
+        int yrb = ((yr > 0.0) ? (int) yr : (int) yr - 1);
+        int zrb = ((zr > 0.0) ? (int) zr : (int) zr - 1);
         double xri = xr - xrb, yri = yr - yrb, zri = zr - zrb;
 
         // Identify which octant of the cube we're in. This determines which cell

--- a/src/main/java/org/spongepowered/noise/NoiseQualitySimplex.java
+++ b/src/main/java/org/spongepowered/noise/NoiseQualitySimplex.java
@@ -1,0 +1,65 @@
+/*
+ * This file is part of Noise, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Flow Powered <https://github.com/flow>
+ * Copyright (c) SpongePowered <https://github.com/SpongePowered>
+ * Copyright (c) contributors
+ *
+ * Original libnoise C++ library by Jason Bevins <http://libnoise.sourceforge.net>
+ * jlibnoise Java port by Garrett Fleenor <https://github.com/RoyAwesome/jlibnoise>
+ * Noise is re-licensed with permission from jlibnoise author.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.noise;
+
+public enum NoiseQualitySimplex {
+    /**
+     * Generates simplex-style noise using the four nearst lattice vertices and smaller kernels. The appearance might be more bubbly, and there might be more straight line segments in the ridged noise.
+     * However, Ridged noise using this setting may still be more favorable than the Perlin / non-Simplex Ridged noise.
+     */
+    STANDARD(0.5, Utils.RANDOM_VECTORS_SIMPLEXSTYLE_STANDARD, Utils.LOOKUP_SIMPLEXSTYLE_STANDARD),
+
+    /**
+     * Generates simplex-style using the eight nearest lattice vertices and larger kernels. The appearance will be smoother, and there will be fewer to no straight line segments in the ridged noise.
+     */
+    SMOOTH(0.75, Utils.RANDOM_VECTORS_SIMPLEXSTYLE_SMOOTH, Utils.LOOKUP_SIMPLEXSTYLE_SMOOTH);
+
+    private double kernelSquaredRadius;
+    private double[] randomVectors;
+    private Utils.LatticePointBCC[] lookup;
+
+    private NoiseQualitySimplex(double kernelSquaredRadius, double[] randomVectors, Utils.LatticePointBCC[] lookup) {
+        this.kernelSquaredRadius = kernelSquaredRadius;
+        this.randomVectors = randomVectors;
+        this.lookup = lookup;
+    }
+
+    public double getKernelSquaredRadius() {
+        return kernelSquaredRadius;
+    }
+
+    public double[] getRandomVectors() {
+        return randomVectors;
+    }
+
+    public Utils.LatticePointBCC[] getLookup() {
+        return lookup;
+    }
+}

--- a/src/main/java/org/spongepowered/noise/Utils.java
+++ b/src/main/java/org/spongepowered/noise/Utils.java
@@ -226,7 +226,8 @@ public final class Utils {
     static {
         // pre-scale the vectors to avoid unnecessary division/multiplication when generating noise
         for (int i = 0; i < RANDOM_VECTORS.length; i++) {
-            RANDOM_VECTORS_S[i] = RANDOM_VECTORS[i] / 0.0185703274687564875;
+            RANDOM_VECTORS_S[i] = RANDOM_VECTORS[i] / 0.0495208732500173; // Make the Simplex-style noise range from 0.3125 to 0.6875
+            //RANDOM_VECTORS_S[i] = RANDOM_VECTORS[i] / 0.0185703274687564875; // Make the Simplex-style noise range from 0 to 1
             RANDOM_VECTORS[i] /= 2 * Math.sqrt(3.0);
         }
     }

--- a/src/main/java/org/spongepowered/noise/Utils.java
+++ b/src/main/java/org/spongepowered/noise/Utils.java
@@ -221,60 +221,139 @@ public final class Utils {
             -0.786182, -0.583814, 0.202678, 0.0, -0.565191, 0.821858, -0.0714658, 0.0, 0.437895, 0.152598, -0.885981, 0.0, -0.92394, 0.353436, -0.14635, 0.0,
             0.212189, -0.815162, -0.538969, 0.0, -0.859262, 0.143405, -0.491024, 0.0, 0.991353, 0.112814, 0.0670273, 0.0, 0.0337884, -0.979891, -0.196654, 0.0
     };
-    public static final double[] RANDOM_VECTORS_S = new double[RANDOM_VECTORS.length];
+    public static final double[] RANDOM_VECTORS_SIMPLEXSTYLE_STANDARD = new double[RANDOM_VECTORS.length];
+    public static final double[] RANDOM_VECTORS_SIMPLEXSTYLE_SMOOTH = new double[RANDOM_VECTORS.length];
+    public static final double[] RANDOM_VECTORS_PERLIN = new double[RANDOM_VECTORS.length];
 
+    // These were computed by gradient ascent using the above gradient set.
+    private static final double NORMALIZER_SIMPLEXSTYLE_STANDARD = 0.0185703274687564875;
+    private static final double NORMALIZER_SIMPLEXSTYLE_SMOOTH = 0.17315490496873540625;
+    private static final double NORMALIZER_PERLIN = 1.7252359327388492;
+
+    // Constant multiplier to translate the range back to what it was before the normalization fix, and perform the equivalent for the simplex-style noise.
+    private static final double COMPATIBILITY_RATIO = 2 * Math.sqrt(3.0) / NORMALIZER_PERLIN;
     static {
-        // pre-scale the vectors to avoid unnecessary division/multiplication when generating noise
+        setupLegacyMode(false);
+    }
+    public static void setupLegacyMode(boolean enableLegacyRange) {
+        double legacyMultiplier = (enableLegacyRange ? COMPATIBILITY_RATIO : 1.0);
         for (int i = 0; i < RANDOM_VECTORS.length; i++) {
-            RANDOM_VECTORS_S[i] = RANDOM_VECTORS[i] / 0.0495208732500173; // Make the Simplex-style noise range from 0.3125 to 0.6875
-            //RANDOM_VECTORS_S[i] = RANDOM_VECTORS[i] / 0.0185703274687564875; // Make the Simplex-style noise range from 0 to 1
-            RANDOM_VECTORS[i] /= 2 * Math.sqrt(3.0);
+            RANDOM_VECTORS_SIMPLEXSTYLE_STANDARD[i] = RANDOM_VECTORS[i] / (legacyMultiplier * NORMALIZER_SIMPLEXSTYLE_STANDARD);
+            RANDOM_VECTORS_SIMPLEXSTYLE_SMOOTH[i] = RANDOM_VECTORS[i] / (legacyMultiplier * NORMALIZER_SIMPLEXSTYLE_SMOOTH);
+            RANDOM_VECTORS_PERLIN[i] = RANDOM_VECTORS[i] / (legacyMultiplier * NORMALIZER_PERLIN);
         }
     }
 
-
     /**
-     * A lookup table to 8 decision trees for the simplex-style noise. Two cubic lattices offset by (0.5, 0.5, 0.5).
+     * Lookup tables to 8 decision trees for the simplex-style noise. Two cubic lattices offset by (0.5, 0.5, 0.5).
      * The current octant of the current cubic cell of the first lattice corresponds to one cell on the second.
-     * From there, at most four lattice vertices are found which are in range of the input point.
+     * From there, at most four ("standard") or eight ("smooth") lattice vertices are found which are in range.
      */
-    public static final LatticePointBCC[] LOOKUP_BCC = new LatticePointBCC[8];
+    public static final LatticePointBCC[] LOOKUP_SIMPLEXSTYLE_STANDARD = new LatticePointBCC[8];
+    public static final LatticePointBCC[] LOOKUP_SIMPLEXSTYLE_SMOOTH = new LatticePointBCC[8];
     static {
         for (int i = 0; i < 8; i++) {
             int i1, j1, k1, i2, j2, k2;
             i1 = (i >> 0) & 1; j1 = (i >> 1) & 1; k1 = (i >> 2) & 1;
             i2 = i1 ^ 1; j2 = j1 ^ 1; k2 = k1 ^ 1;
 
+            /*
+             * Quality: Standard. Resolve nearest 4 points.
+             */
+
             // The two points within this octant, one from each of the two cubic half-lattices.
-            LatticePointBCC c0 = new LatticePointBCC(i1, j1, k1, 0);
-            LatticePointBCC c1 = new LatticePointBCC(i1 + i2, j1 + j2, k1 + k2, 1);
+            LatticePointBCC csf0 = new LatticePointBCC(i1, j1, k1, 0);
+            LatticePointBCC csf1 = new LatticePointBCC(i1 + i2, j1 + j2, k1 + k2, 1);
 
             // Each single step away on the first half-lattice.
-            LatticePointBCC c2 = new LatticePointBCC(i1 ^ 1, j1, k1, 0);
-            LatticePointBCC c3 = new LatticePointBCC(i1, j1 ^ 1, k1, 0);
-            LatticePointBCC c4 = new LatticePointBCC(i1, j1, k1 ^ 1, 0);
+            LatticePointBCC csf2 = new LatticePointBCC(i1 ^ 1, j1, k1, 0);
+            LatticePointBCC csf3 = new LatticePointBCC(i1, j1 ^ 1, k1, 0);
+            LatticePointBCC csf4 = new LatticePointBCC(i1, j1, k1 ^ 1, 0);
 
             // Each single step away on the second half-lattice.
-            LatticePointBCC c5 = new LatticePointBCC(i1 + (i2 ^ 1), j1 + j2, k1 + k2, 1);
-            LatticePointBCC c6 = new LatticePointBCC(i1 + i2, j1 + (j2 ^ 1), k1 + k2, 1);
-            LatticePointBCC c7 = new LatticePointBCC(i1 + i2, j1 + j2, k1 + (k2 ^ 1), 1);
+            LatticePointBCC csf5 = new LatticePointBCC(i1 + (i2 ^ 1), j1 + j2, k1 + k2, 1);
+            LatticePointBCC csf6 = new LatticePointBCC(i1 + i2, j1 + (j2 ^ 1), k1 + k2, 1);
+            LatticePointBCC csf7 = new LatticePointBCC(i1 + i2, j1 + j2, k1 + (k2 ^ 1), 1);
 
             // First two are guaranteed.
-            c0.nextOnFailure = c0.nextOnSuccess = c1;
-            c1.nextOnFailure = c1.nextOnSuccess = c2;
+            csf0.nextOnFailure = csf0.nextOnSuccess = csf1;
+            csf1.nextOnFailure = csf1.nextOnSuccess = csf2;
 
             // Once we find one on the first half-lattice, the rest are out.
-            // In addition, knowing c2 rules out c5.
-            c2.nextOnFailure = c3; c2.nextOnSuccess = c6;
-            c3.nextOnFailure = c4; c3.nextOnSuccess = c5;
-            c4.nextOnFailure = c4.nextOnSuccess = c5;
+            // In addition, knowing csf2 rules out csf5.
+            csf2.nextOnFailure = csf3; csf2.nextOnSuccess = csf6;
+            csf3.nextOnFailure = csf4; csf3.nextOnSuccess = csf5;
+            csf4.nextOnFailure = csf4.nextOnSuccess = csf5;
 
             // Once we find one on the second half-lattice, the rest are out.
-            c5.nextOnFailure = c6; c5.nextOnSuccess = null;
-            c6.nextOnFailure = c7; c6.nextOnSuccess = null;
-            c7.nextOnFailure = c7.nextOnSuccess = null;
+            csf5.nextOnFailure = csf6; csf5.nextOnSuccess = null;
+            csf6.nextOnFailure = csf7; csf6.nextOnSuccess = null;
+            csf7.nextOnFailure = csf7.nextOnSuccess = null;
 
-            LOOKUP_BCC[i] = c0;
+            LOOKUP_SIMPLEXSTYLE_STANDARD[i] = csf0;
+
+            /*
+             * Quality: Smooth. Resolve nearest 8 points.
+             */
+
+            // The two points within this octant, one from each of the two cubic half-lattices.
+            LatticePointBCC css0 = new LatticePointBCC(i1, j1, k1, 0);
+            LatticePointBCC css1 = new LatticePointBCC(i1 + i2, j1 + j2, k1 + k2, 1);
+
+            // (1, 0, 0) vs (0, 1, 1) away from octant.
+            LatticePointBCC css2 = new LatticePointBCC(i1 ^ 1, j1, k1, 0);
+            LatticePointBCC css3 = new LatticePointBCC(i1, j1 ^ 1, k1 ^ 1, 0);
+
+            // (1, 0, 0) vs (0, 1, 1) away from octant, on second half-lattice.
+            LatticePointBCC css4 = new LatticePointBCC(i1 + (i2 ^ 1), j1 + j2, k1 + k2, 1);
+            LatticePointBCC css5 = new LatticePointBCC(i1 + i2, j1 + (j2 ^ 1), k1 + (k2 ^ 1), 1);
+
+            // (0, 1, 0) vs (1, 0, 1) away from octant.
+            LatticePointBCC css6 = new LatticePointBCC(i1, j1 ^ 1, k1, 0);
+            LatticePointBCC css7 = new LatticePointBCC(i1 ^ 1, j1, k1 ^ 1, 0);
+
+            // (0, 1, 0) vs (1, 0, 1) away from octant, on second half-lattice.
+            LatticePointBCC css8 = new LatticePointBCC(i1 + i2, j1 + (j2 ^ 1), k1 + k2, 1);
+            LatticePointBCC css9 = new LatticePointBCC(i1 + (i2 ^ 1), j1 + j2, k1 + (k2 ^ 1), 1);
+
+            // (0, 0, 1) vs (1, 1, 0) away from octant.
+            LatticePointBCC cssA = new LatticePointBCC(i1, j1, k1 ^ 1, 0);
+            LatticePointBCC cssB = new LatticePointBCC(i1 ^ 1, j1 ^ 1, k1, 0);
+
+            // (0, 0, 1) vs (1, 1, 0) away from octant, on second half-lattice.
+            LatticePointBCC cssC = new LatticePointBCC(i1 + i2, j1 + j2, k1 + (k2 ^ 1), 1);
+            LatticePointBCC cssD = new LatticePointBCC(i1 + (i2 ^ 1), j1 + (j2 ^ 1), k1 + k2, 1);
+
+            // First two points are guaranteed.
+            css0.nextOnFailure = css0.nextOnSuccess = css1;
+            css1.nextOnFailure = css1.nextOnSuccess = css2;
+
+            // If css2 is in range, then we know css3 and css4 are not.
+            css2.nextOnFailure = css3; css2.nextOnSuccess = css5;
+            css3.nextOnFailure = css4; css3.nextOnSuccess = css4;
+
+            // If css4 is in range, then we know css5 is not.
+            css4.nextOnFailure = css5; css4.nextOnSuccess = css6;
+            css5.nextOnFailure = css5.nextOnSuccess = css6;
+
+            // If css6 is in range, then we know css7 and css8 are not.
+            css6.nextOnFailure = css7; css6.nextOnSuccess = css9;
+            css7.nextOnFailure = css8; css7.nextOnSuccess = css8;
+
+            // If css8 is in range, then we know css9 is not.
+            css8.nextOnFailure = css9; css8.nextOnSuccess = cssA;
+            css9.nextOnFailure = css9.nextOnSuccess = cssA;
+
+            // If cssA is in range, then we know cssB and cssC are not.
+            cssA.nextOnFailure = cssB; cssA.nextOnSuccess = cssD;
+            cssB.nextOnFailure = cssC; cssB.nextOnSuccess = cssC;
+
+            // If cssC is in range, then we know cssD is not.
+            cssC.nextOnFailure = cssD; cssC.nextOnSuccess = null;
+            cssD.nextOnFailure = cssD.nextOnSuccess = null;
+
+            LOOKUP_SIMPLEXSTYLE_SMOOTH[i] = css0;
+
         }
     }
 
@@ -287,7 +366,7 @@ public final class Utils {
         LatticePointBCC nextOnFailure, nextOnSuccess;
         public LatticePointBCC(int xrv, int yrv, int zrv, int lattice) {
             this.dxr = -xrv + lattice * 0.5; this.dyr = -yrv + lattice * 0.5; this.dzr = -zrv + lattice * 0.5;
-            this.xrv = xrv + lattice * 1024; this.yrv = yrv + lattice * 1024; this.zrv = zrv + lattice * 1024;
+            this.xrv = xrv + lattice * 0x8000; this.yrv = yrv + lattice * 0x8000; this.zrv = zrv + lattice * 0x8000;
         }
     }
 }

--- a/src/main/java/org/spongepowered/noise/module/source/RidgedMulti.java
+++ b/src/main/java/org/spongepowered/noise/module/source/RidgedMulti.java
@@ -118,6 +118,19 @@ public class RidgedMulti extends Module {
         }
     }
 
+    /**
+     * Returns the maximum value the RidgedMulti module can output in its current configuration
+     * @return The maximum possible value for {@link RidgedMulti#getValue(double, double, double)} to return
+     */
+    public double getMaxValue() {
+    	/*
+    	 * Each successive octave adds (1/lacunarity) ^ current_octaves to max possible output.
+    	 * So (r = lacunarity, o = octave): Max(ridged) = 1 + 1/r + 1/(r*r) + 1/(r*r*r) + ... + (1/r^(o-1))
+    	 * See https://www.wolframalpha.com/input/?i=sum+from+k%3D0+to+n-1+of+1%2Fx%5Ek
+    	 */
+        return (getLacunarity() - Math.pow(getLacunarity(), 1 - getOctaveCount())) / (getLacunarity() - 1) / 1.6;
+    }
+
     @Override
     public int getSourceModuleCount() {
         return 0;

--- a/src/main/java/org/spongepowered/noise/module/source/RidgedMultiSimplex.java
+++ b/src/main/java/org/spongepowered/noise/module/source/RidgedMultiSimplex.java
@@ -39,17 +39,15 @@ import org.spongepowered.noise.module.Module;
  * Uses a different formula but produces a similar appearance to classic Simplex.
  */
 public class RidgedMultiSimplex extends Module {
-    // Default frequency for the noise::module::RidgedMulti noise module.
+    // Default frequency for the noise::module::RidgedMultiSimplex noise module.
     public static final double DEFAULT_RIDGED_FREQUENCY = 1.0;
-    // Default lacunarity for the noise::module::RidgedMulti noise module.
+    // Default lacunarity for the noise::module::RidgedMultiSimplex noise module.
     public static final double DEFAULT_RIDGED_LACUNARITY = 2.0;
-    // Default number of octaves for the noise::module::RidgedMulti noise module.
+    // Default number of octaves for the noise::module::RidgedMultiSimplex noise module.
     public static final int DEFAULT_RIDGED_OCTAVE_COUNT = 6;
-    // Default noise quality for the noise::module::RidgedMulti noise module.
-    public static final NoiseQuality DEFAULT_RIDGED_QUALITY = NoiseQuality.STANDARD;
-    // Default noise seed for the noise::module::RidgedMulti noise module.
+    // Default noise seed for the noise::module::RidgedMultiSimplex noise module.
     public static final int DEFAULT_RIDGED_SEED = 0;
-    // Maximum number of octaves for the noise::module::RidgedMulti noise module.
+    // Maximum number of octaves for the noise::module::RidgedMultiSimplex noise module.
     public static final int RIDGED_MAX_OCTAVE = 30;
     private double frequency = DEFAULT_RIDGED_FREQUENCY;
     // Frequency multiplier between successive octaves.

--- a/src/main/java/org/spongepowered/noise/module/source/RidgedMultiSimplex.java
+++ b/src/main/java/org/spongepowered/noise/module/source/RidgedMultiSimplex.java
@@ -37,7 +37,7 @@ import org.spongepowered.noise.module.Module;
 
 /**
  * Generates ridged Simplex-style noise. The base Simplex uses a different formula but produces a similar appearance to classic Simplex.
- * Default lattice orientation is XZBeforeY. See {@link org.spongepowered.noise.LatticeOrientation} for recommended usage.
+ * Default lattice orientation is XZ_BEFORE_Y. See {@link org.spongepowered.noise.LatticeOrientation} for recommended usage.
  */
 public class RidgedMultiSimplex extends Module {
     // Default frequency for the noise::module::RidgedMultiSimplex noise module.
@@ -47,7 +47,7 @@ public class RidgedMultiSimplex extends Module {
     // Default number of octaves for the noise::module::RidgedMultiSimplex noise module.
     public static final int DEFAULT_RIDGED_OCTAVE_COUNT = 6;
     // Default lattice orientation for the noise::module::Simplex noise module.
-    public static final LatticeOrientation DEFAULT_SIMPLEX_ORIENTATION = LatticeOrientation.XZBeforeY;
+    public static final LatticeOrientation DEFAULT_SIMPLEX_ORIENTATION = LatticeOrientation.XZ_BEFORE_Y;
     // Default noise quality for the noise::module::RidgedMultiSimplex noise module.
     public static final NoiseQualitySimplex DEFAULT_RIDGED_QUALITY = NoiseQualitySimplex.SMOOTH;
     // Default noise seed for the noise::module::RidgedMultiSimplex noise module.

--- a/src/main/java/org/spongepowered/noise/module/source/RidgedMultiSimplex.java
+++ b/src/main/java/org/spongepowered/noise/module/source/RidgedMultiSimplex.java
@@ -1,0 +1,183 @@
+/*
+ * This file is part of Noise, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) Flow Powered <https://github.com/flow>
+ * Copyright (c) SpongePowered <https://github.com/SpongePowered>
+ * Copyright (c) contributors
+ *
+ * Original libnoise C++ library by Jason Bevins <http://libnoise.sourceforge.net>
+ * jlibnoise Java port by Garrett Fleenor <https://github.com/RoyAwesome/jlibnoise>
+ * Noise is re-licensed with permission from jlibnoise author.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.spongepowered.noise.module.source;
+
+import org.spongepowered.noise.Noise;
+import org.spongepowered.noise.NoiseQuality;
+import org.spongepowered.noise.Utils;
+import org.spongepowered.noise.module.Module;
+
+/**
+ * Generates ridged Simplex-style noise.
+ * Uses a different formula but produces a similar appearance to classic Simplex.
+ */
+public class RidgedMultiSimplex extends Module {
+    // Default frequency for the noise::module::RidgedMulti noise module.
+    public static final double DEFAULT_RIDGED_FREQUENCY = 1.0;
+    // Default lacunarity for the noise::module::RidgedMulti noise module.
+    public static final double DEFAULT_RIDGED_LACUNARITY = 2.0;
+    // Default number of octaves for the noise::module::RidgedMulti noise module.
+    public static final int DEFAULT_RIDGED_OCTAVE_COUNT = 6;
+    // Default noise quality for the noise::module::RidgedMulti noise module.
+    public static final NoiseQuality DEFAULT_RIDGED_QUALITY = NoiseQuality.STANDARD;
+    // Default noise seed for the noise::module::RidgedMulti noise module.
+    public static final int DEFAULT_RIDGED_SEED = 0;
+    // Maximum number of octaves for the noise::module::RidgedMulti noise module.
+    public static final int RIDGED_MAX_OCTAVE = 30;
+    private double frequency = DEFAULT_RIDGED_FREQUENCY;
+    // Frequency multiplier between successive octaves.
+    private double lacunarity = DEFAULT_RIDGED_LACUNARITY;
+    // Total number of octaves that generate the ridged-multifractal noise.
+    private int octaveCount = DEFAULT_RIDGED_OCTAVE_COUNT;
+    // Contains the spectral weights for each octave.
+    private double[] spectralWeights;
+    // Seed value used by the ridged-multfractal-noise function.
+    private int seed = DEFAULT_RIDGED_SEED;
+
+    public RidgedMultiSimplex() {
+        super(0);
+        calcSpectralWeights();
+    }
+
+    public double getFrequency() {
+        return frequency;
+    }
+
+    public void setFrequency(double frequency) {
+        this.frequency = frequency;
+    }
+
+    public double getLacunarity() {
+        return lacunarity;
+    }
+
+    public void setLacunarity(double lacunarity) {
+        this.lacunarity = lacunarity;
+    }
+
+    public int getOctaveCount() {
+        return octaveCount;
+    }
+
+    public void setOctaveCount(int octaveCount) {
+        this.octaveCount = Math.min(octaveCount, RIDGED_MAX_OCTAVE);
+    }
+
+    public int getSeed() {
+        return seed;
+    }
+
+    public void setSeed(int seed) {
+        this.seed = seed;
+    }
+
+    private void calcSpectralWeights() {
+        // This exponent parameter should be user-defined; it may be exposed in a
+        // future version of libnoise.
+        double h = 1.0;
+
+        double frequency = 1.0;
+        spectralWeights = new double[RIDGED_MAX_OCTAVE];
+        for (int i = 0; i < RIDGED_MAX_OCTAVE; i++) {
+            // Compute weight for each frequency.
+            spectralWeights[i] = Math.pow(frequency, -h);
+            frequency *= lacunarity;
+        }
+    }
+
+    @Override
+    public int getSourceModuleCount() {
+        return 0;
+    }
+
+    @Override
+    public double getValue(double x, double y, double z) {
+        double x1 = x;
+        double y1 = y;
+        double z1 = z;
+        x1 *= frequency;
+        y1 *= frequency;
+        z1 *= frequency;
+
+        double signal;
+        double value = 0.0;
+        double weight = 1.0;
+
+        // These parameters should be user-defined; they may be exposed in a
+        // future version of libnoise.
+        double offset = 1.0;
+        double gain = 2.0;
+
+        for (int curOctave = 0; curOctave < octaveCount; curOctave++) {
+
+            // Make sure that these floating-point values have the same range as a 32-
+            // bit integer so that we can pass them to the coherent-noise functions.
+            double nx, ny, nz;
+            nx = Utils.makeInt32Range(x1);
+            ny = Utils.makeInt32Range(y1);
+            nz = Utils.makeInt32Range(z1);
+
+            // Get the coherent-noise value.
+            int seed = (this.seed + curOctave) & 0x7fffffff;
+            signal = Noise.simplexStyleCoherentNoise3D(nx, ny, nz, seed) * 2 - 1;
+
+            // Make the ridges.
+            signal = Math.abs(signal);
+            signal = offset - signal;
+
+            // Square the signal to increase the sharpness of the ridges.
+            signal *= signal;
+
+            // The weighting from the previous octave is applied to the signal.
+            // Larger values have higher weights, producing sharp points along the
+            // ridges.
+            signal *= weight;
+
+            // Weight successive contributions by the previous signal.
+            weight = signal * gain;
+            if (weight > 1.0) {
+                weight = 1.0;
+            }
+            if (weight < 0.0) {
+                weight = 0.0;
+            }
+
+            // Add the signal to the output value.
+            value += (signal * spectralWeights[curOctave]);
+
+            // Go to the next octave.
+            x1 *= lacunarity;
+            y1 *= lacunarity;
+            z1 *= lacunarity;
+        }
+
+        return value / 1.6;
+    }
+}

--- a/src/main/java/org/spongepowered/noise/module/source/Simplex.java
+++ b/src/main/java/org/spongepowered/noise/module/source/Simplex.java
@@ -37,7 +37,7 @@ import org.spongepowered.noise.module.Module;
 
 /**
  * Generates summed octave Simplex-style noise. The base Simplex uses a different formula but produces a similar appearance to classic Simplex.
- * Default lattice orientation is XZBeforeY. See {@link org.spongepowered.noise.LatticeOrientation} for recommended usage.
+ * Default lattice orientation is XZ_BEFORE_Y. See {@link org.spongepowered.noise.LatticeOrientation} for recommended usage.
  */
 public class Simplex extends Module {
     // Default frequency for the noise::module::Simplex noise module.
@@ -49,7 +49,7 @@ public class Simplex extends Module {
     // Default persistence value for the noise::module::Simplex noise module.
     public static final double DEFAULT_SIMPLEX_PERSISTENCE = 0.5;
     // Default lattice orientation for the noise::module::Simplex noise module.
-    public static final LatticeOrientation DEFAULT_SIMPLEX_ORIENTATION = LatticeOrientation.XZBeforeY;
+    public static final LatticeOrientation DEFAULT_SIMPLEX_ORIENTATION = LatticeOrientation.XZ_BEFORE_Y;
     // Default noise quality for the noise::module::Simplex noise module.
     public static final NoiseQualitySimplex DEFAULT_SIMPLEX_QUALITY = NoiseQualitySimplex.STANDARD;
     // Default noise seed for the noise::module::Simplex noise module.

--- a/src/main/java/org/spongepowered/noise/module/source/Simplex.java
+++ b/src/main/java/org/spongepowered/noise/module/source/Simplex.java
@@ -34,35 +34,35 @@ import org.spongepowered.noise.NoiseQuality;
 import org.spongepowered.noise.Utils;
 import org.spongepowered.noise.module.Module;
 
-public class Perlin extends Module {
-    // Default frequency for the noise::module::Perlin noise module.
-    public static final double DEFAULT_PERLIN_FREQUENCY = 1.0;
-    // Default lacunarity for the noise::module::Perlin noise module.
-    public static final double DEFAULT_PERLIN_LACUNARITY = 2.0;
-    // Default number of octaves for the noise::module::Perlin noise module.
-    public static final int DEFAULT_PERLIN_OCTAVE_COUNT = 6;
-    // Default persistence value for the noise::module::Perlin noise module.
-    public static final double DEFAULT_PERLIN_PERSISTENCE = 0.5;
-    // Default noise quality for the noise::module::Perlin noise module.
-    public static final NoiseQuality DEFAULT_PERLIN_QUALITY = NoiseQuality.STANDARD;
-    // Default noise seed for the noise::module::Perlin noise module.
-    public static final int DEFAULT_PERLIN_SEED = 0;
-    // Maximum number of octaves for the noise::module::Perlin noise module.
-    public static final int PERLIN_MAX_OCTAVE = 30;
+/**
+ * Generates summed octave Simplex-style noise.
+ * Uses a different formula but produces a similar appearance to classic Simplex.
+ */
+public class Simplex extends Module {
+    // Default frequency for the noise::module::Simplex noise module.
+    public static final double DEFAULT_SIMPLEX_FREQUENCY = 1.0;
+    // Default lacunarity for the noise::module::Simplex noise module.
+    public static final double DEFAULT_SIMPLEX_LACUNARITY = 2.0;
+    // Default number of octaves for the noise::module::Simplex noise module.
+    public static final int DEFAULT_SIMPLEX_OCTAVE_COUNT = 6;
+    // Default persistence value for the noise::module::Simplex noise module.
+    public static final double DEFAULT_SIMPLEX_PERSISTENCE = 0.5;
+    // Default noise seed for the noise::module::Simplex noise module.
+    public static final int DEFAULT_SIMPLEX_SEED = 0;
+    // Maximum number of octaves for the noise::module::Simplex noise module.
+    public static final int SIMPLEX_MAX_OCTAVE = 30;
     // Frequency of the first octave.
-    private double frequency = DEFAULT_PERLIN_FREQUENCY;
+    private double frequency = DEFAULT_SIMPLEX_FREQUENCY;
     // Frequency multiplier between successive octaves.
-    private double lacunarity = DEFAULT_PERLIN_LACUNARITY;
-    // Quality of the Perlin noise.
-    private NoiseQuality noiseQuality = DEFAULT_PERLIN_QUALITY;
-    // Total number of octaves that generate the Perlin noise.
-    private int octaveCount = DEFAULT_PERLIN_OCTAVE_COUNT;
-    // Persistence of the Perlin noise.
-    private double persistence = DEFAULT_PERLIN_PERSISTENCE;
-    // Seed value used by the Perlin-noise function.
-    private int seed = DEFAULT_PERLIN_SEED;
+    private double lacunarity = DEFAULT_SIMPLEX_LACUNARITY;
+    // Total number of octaves that generate the Simplex noise.
+    private int octaveCount = DEFAULT_SIMPLEX_OCTAVE_COUNT;
+    // Persistence of the Simplex noise.
+    private double persistence = DEFAULT_SIMPLEX_PERSISTENCE;
+    // Seed value used by the Simplex-noise function.
+    private int seed = DEFAULT_SIMPLEX_SEED;
 
-    public Perlin() {
+    public Simplex() {
         super(0);
     }
 
@@ -82,21 +82,13 @@ public class Perlin extends Module {
         this.lacunarity = lacunarity;
     }
 
-    public NoiseQuality getNoiseQuality() {
-        return noiseQuality;
-    }
-
-    public void setNoiseQuality(NoiseQuality noiseQuality) {
-        this.noiseQuality = noiseQuality;
-    }
-
     public int getOctaveCount() {
         return octaveCount;
     }
 
     public void setOctaveCount(int octaveCount) {
-        if (octaveCount < 1 || octaveCount > PERLIN_MAX_OCTAVE) {
-            throw new IllegalArgumentException("octaveCount must be between 1 and MAX OCTAVE: " + PERLIN_MAX_OCTAVE);
+        if (octaveCount < 1 || octaveCount > SIMPLEX_MAX_OCTAVE) {
+            throw new IllegalArgumentException("octaveCount must be between 1 and MAX OCTAVE: " + SIMPLEX_MAX_OCTAVE);
         }
 
         this.octaveCount = octaveCount;
@@ -119,8 +111,8 @@ public class Perlin extends Module {
     }
     
     /**
-     * Returns the maximum value the perlin module can output in its current configuration
-     * @return The maximum possible value for {@link Perlin#getValue(double, double, double)} to return
+     * Returns the maximum value the simplex module can output in its current configuration
+     * @return The maximum possible value for {@link Simplex#getValue(double, double, double)} to return
      */
     public double getMaxValue() {
     	/*
@@ -162,7 +154,7 @@ public class Perlin extends Module {
             // Get the coherent-noise value from the input value and add it to the
             // final result.
             seed = (this.seed + curOctave);
-            signal = Noise.gradientCoherentNoise3D(nx, ny, nz, seed, noiseQuality);
+            signal = Noise.simplexStyleCoherentNoise3D(nx, ny, nz, seed);
             value += signal * curPersistence;
 
             // Prepare the next octave.

--- a/src/main/java/org/spongepowered/noise/module/source/Simplex.java
+++ b/src/main/java/org/spongepowered/noise/module/source/Simplex.java
@@ -30,13 +30,14 @@
 package org.spongepowered.noise.module.source;
 
 import org.spongepowered.noise.Noise;
-import org.spongepowered.noise.NoiseQuality;
+import org.spongepowered.noise.LatticeOrientation;
+import org.spongepowered.noise.NoiseQualitySimplex;
 import org.spongepowered.noise.Utils;
 import org.spongepowered.noise.module.Module;
 
 /**
- * Generates summed octave Simplex-style noise.
- * Uses a different formula but produces a similar appearance to classic Simplex.
+ * Generates summed octave Simplex-style noise. The base Simplex uses a different formula but produces a similar appearance to classic Simplex.
+ * Default lattice orientation is XZBeforeY. See {@link org.spongepowered.noise.LatticeOrientation} for recommended usage.
  */
 public class Simplex extends Module {
     // Default frequency for the noise::module::Simplex noise module.
@@ -47,6 +48,10 @@ public class Simplex extends Module {
     public static final int DEFAULT_SIMPLEX_OCTAVE_COUNT = 6;
     // Default persistence value for the noise::module::Simplex noise module.
     public static final double DEFAULT_SIMPLEX_PERSISTENCE = 0.5;
+    // Default lattice orientation for the noise::module::Simplex noise module.
+    public static final LatticeOrientation DEFAULT_SIMPLEX_ORIENTATION = LatticeOrientation.XZBeforeY;
+    // Default noise quality for the noise::module::Simplex noise module.
+    public static final NoiseQualitySimplex DEFAULT_SIMPLEX_QUALITY = NoiseQualitySimplex.STANDARD;
     // Default noise seed for the noise::module::Simplex noise module.
     public static final int DEFAULT_SIMPLEX_SEED = 0;
     // Maximum number of octaves for the noise::module::Simplex noise module.
@@ -55,11 +60,15 @@ public class Simplex extends Module {
     private double frequency = DEFAULT_SIMPLEX_FREQUENCY;
     // Frequency multiplier between successive octaves.
     private double lacunarity = DEFAULT_SIMPLEX_LACUNARITY;
-    // Total number of octaves that generate the Simplex noise.
+    // Lattice Orientation of the Simplex-style noise.
+    private LatticeOrientation latticeOrientation = DEFAULT_SIMPLEX_ORIENTATION;
+    // Quality of the Simplex-style noise.
+    private NoiseQualitySimplex noiseQuality = DEFAULT_SIMPLEX_QUALITY;
+    // Total number of octaves that generate the Simplex-style noise.
     private int octaveCount = DEFAULT_SIMPLEX_OCTAVE_COUNT;
-    // Persistence of the Simplex noise.
+    // Persistence of the Simplex-style noise.
     private double persistence = DEFAULT_SIMPLEX_PERSISTENCE;
-    // Seed value used by the Simplex-noise function.
+    // Seed value used by the Simplex-style noise function.
     private int seed = DEFAULT_SIMPLEX_SEED;
 
     public Simplex() {
@@ -80,6 +89,22 @@ public class Simplex extends Module {
 
     public void setLacunarity(double lacunarity) {
         this.lacunarity = lacunarity;
+    }
+
+    public LatticeOrientation getLatticeOrientation() {
+        return latticeOrientation;
+    }
+
+    public void setLatticeOrientation(LatticeOrientation latticeOrientation) {
+        this.latticeOrientation = latticeOrientation;
+    }
+
+    public NoiseQualitySimplex getNoiseQuality() {
+        return noiseQuality;
+    }
+
+    public void setNoiseQuality(NoiseQualitySimplex noiseQuality) {
+        this.noiseQuality = noiseQuality;
     }
 
     public int getOctaveCount() {
@@ -117,7 +142,7 @@ public class Simplex extends Module {
     public double getMaxValue() {
     	/*
     	 * Each successive octave adds persistence ^ current_octaves to max possible output.
-    	 * So (p = persistence, o = octave): Max(perlin) = p + p*p + p*p*p + ... + p^(o-1).
+    	 * So (p = persistence, o = octave): Max(simplex) = p + p*p + p*p*p + ... + p^(o-1).
     	 * Using geometric series formula we can narrow it down to this:
     	 */
     	return (Math.pow(getPersistence(), getOctaveCount()) - 1) / (getPersistence() - 1);
@@ -154,7 +179,7 @@ public class Simplex extends Module {
             // Get the coherent-noise value from the input value and add it to the
             // final result.
             seed = (this.seed + curOctave);
-            signal = Noise.simplexStyleCoherentNoise3D(nx, ny, nz, seed);
+            signal = Noise.simplexStyleGradientCoherentNoise3D(nx, ny, nz, seed, latticeOrientation, noiseQuality);
             value += signal * curPersistence;
 
             // Prepare the next octave.

--- a/src/test/java/org/spongepowered/noise/NoiseTest.java
+++ b/src/test/java/org/spongepowered/noise/NoiseTest.java
@@ -37,14 +37,32 @@ import org.junit.Test;
 public class NoiseTest {
     @Test
     public void test() throws IOException {
-        double max = -Double.MAX_VALUE;
+
+        // Euclidean norm check
         for (int i = 0; i < Utils.RANDOM_VECTORS.length >> 2; i++) {
-            final double gradient = Math.abs(Utils.RANDOM_VECTORS[i << 2]) + Math.abs(Utils.RANDOM_VECTORS[(i << 2) + 1]) + Math.abs(Utils.RANDOM_VECTORS[(i << 2) + 2]);
-            if (gradient > max) {
-                max = gradient;
-            }
+            double gradientMagnitudeSquared =
+                    (Utils.RANDOM_VECTORS[i << 2] * Utils.RANDOM_VECTORS[i << 2])
+                    + (Utils.RANDOM_VECTORS[(i << 2) + 1] * Utils.RANDOM_VECTORS[(i << 2) + 1])
+                    + (Utils.RANDOM_VECTORS[(i << 2) + 2] * Utils.RANDOM_VECTORS[(i << 2) + 2]);
+            Assert.assertEquals("Gradient[i=" + i + "] Euclidean Norm, " + gradientMagnitudeSquared
+                    + ", { " + Utils.RANDOM_VECTORS[i << 2] + ", " + Utils.RANDOM_VECTORS[(i << 2) + 1] + ", " + Utils.RANDOM_VECTORS[(i << 2) + 2] + " }",
+                    gradientMagnitudeSquared, 1.0, 0.00001);
         }
-        Assert.assertEquals(max, 0.5, 0.01);
+
+        // Rudimentary Perlin range test.
+        // Fails when normalized for the actual maximum, rather than for the theoretical sqrt(3) for if arbitrary gradient directions were possible.
+        // It would be more difficult to test the actual maximum in here. In favor of better-normalized noise, I loosened up the condition, instead
+        // of normalizing the gradient set by the theoretical sqrt(3). ~K.jpg
+        for (int i = 0; i < Utils.RANDOM_VECTORS.length >> 2; i++) {
+            double gradientMaximumRampedValue =
+                    Math.abs(Utils.RANDOM_VECTORS_PERLIN[i << 2])
+                    +  Math.abs(Utils.RANDOM_VECTORS_PERLIN[(i << 2) + 1])
+                    +  Math.abs(Utils.RANDOM_VECTORS_PERLIN[(i << 2) + 2]);
+            Assert.assertTrue("Gradient[i=" + i + "] Perlin Range, " + gradientMaximumRampedValue
+                            + ", { " + Utils.RANDOM_VECTORS[i << 2] + ", " + Utils.RANDOM_VECTORS[(i << 2) + 1] + ", " + Utils.RANDOM_VECTORS[(i << 2) + 2] + " }",
+                    gradientMaximumRampedValue <= 1.01); // Would be 1.0 if normalized under the assumption that any gradient direction were possible.
+        }
+
         /*
         final int width = 2048, height = 2048;
         final double xPeriod = 128, yPeriod = 128;


### PR DESCRIPTION
I added "Simplex" modules to go alongside the "Perlin" modules. Simplex noise produces less visibly grid-aligned results than Perlin. Most of the cases where I see Perlin noise used, appear to be more due to convenience or familiarity, than it being the best choice for the application. I tried to adapt the Simplex modules as closely as possible to the existing framework of the library.

I used an alternative algorithm, instead of the classic 3D Simplex noise. There may be issues with using the classic 3D Simplex noise algorithm for certain purposes at the current time. The alternative produces a similar appearance, but uses a much different process. I originally uploaded the algorithm here: https://github.com/KdotJPG/New-Simplex-Style-Gradient-Noise.

I included three "LatticeOrientation" options for the Simplex-style noise. Two of them better optimize the appearance of the noise for common use cases which treat a "vertical" or "time" direction differently than the two "horizontal" directions. The other one serves as a closer replacement for classic Simplex noise.

I included two "NoiseQualitySimplex" options: STANDARD and SMOOTH. STANDARD produces the bubbly appearance that most Simplex-style noise produces. SMOOTH produces a smoother appearance with more constant curvature. It takes a little bit longer to evaluate, but it produces fewer straight-line segments in the ridged noise, and might be favorable when only one octave is used in non-ridged noise. I set the default for non-Ridged to "STANDARD", and the default for Ridged noise to "SMOOTH".

The range was previously much smaller than 0 to 1, as brought up by Issue #18. I corrected the range, and introduced a legacy mode that reverts the library back to the old range. It even simulates the old range on the Simplex-style noise. I computed the range using many iterations of gradient ascent with many random starting values, given the library's gradient set. The gradient ascent always choose the maximizing gradient directions for each corner, out of this set. This way the range is more exact than it would be if it were assumed that any gradient direction were possible. Note: I did see three different results for the different "qualities" of the Perlin. But they were very close, so I just picked the largest. My results were FAST: 1.7252359327388492, STANDARD: 1.7249485110778336, BEST: 1.7248336589880238.

Some variants of Ridged Noise maintain a range of 0 to 1 by design, because they use only multiplications to build up the final value. But this one uses addition, so I added a getMaxValue method just as the non-ridged modules provide.

![image](https://user-images.githubusercontent.com/8829856/72212965-cf021800-34b4-11ea-89be-b03ca37746eb.png)
![image](https://user-images.githubusercontent.com/8829856/72212968-d3c6cc00-34b4-11ea-8370-ab46158734bb.png)
![image](https://user-images.githubusercontent.com/8829856/72212972-d9241680-34b4-11ea-8b1b-6a170c4d4467.png)
![image](https://user-images.githubusercontent.com/8829856/72212974-dde8ca80-34b4-11ea-9d66-1d4e1862d34f.png)
![image](https://user-images.githubusercontent.com/8829856/72212977-e0e3bb00-34b4-11ea-8970-5248b03dbcaa.png)
![image](https://user-images.githubusercontent.com/8829856/72212983-f48f2180-34b4-11ea-8409-1a8832ad5065.png)
